### PR TITLE
LTC-86 -- FIX THE BLUE APP BAR

### DIFF
--- a/src/components/HeroSection/HeroSection.module.scss
+++ b/src/components/HeroSection/HeroSection.module.scss
@@ -84,7 +84,6 @@
     }
 
     h2 {
-      margin-bottom: 0rem;
       max-height: 4rem;
     }
   }

--- a/src/components/HeroSection/HeroSection.module.scss
+++ b/src/components/HeroSection/HeroSection.module.scss
@@ -11,7 +11,7 @@
     font-size: 2.5rem;
     font-weight: 800;
     grid-area: header;
-    margin-top: 0rem;
+    margin-top: auto;
     margin-bottom: 1rem;
   }
 

--- a/src/components/HeroSection/HeroSection.tsx
+++ b/src/components/HeroSection/HeroSection.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import styles from './HeroSection.module.scss'
 import { Button } from '@/components/Button/Button'
+import Image from 'next/image'
+
 interface HeroSectionProps {
   headerText: string
   bodyText: string
@@ -16,7 +18,7 @@ export const HeroSection = ({ headerText, bodyText, image, altText, isFlipped }:
           <div className={styles.bodyText}>{bodyText}</div>
           <Button onClick={() => {}}>Start Watching</Button>
           <div className={styles.imageContainer}>
-              <img alt={altText} src={image}/>
+              <Image alt={altText} src={image} style={{ width: '80%', height: 'auto' }} width={12} height={12}/>
           </div>
       </div>
   )

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { MenuRounded } from '@mui/icons-material'
 import styles from './NavBar.module.scss'
 import { Button } from '@/components/Button/Button'
-import { AppBar, Box, Drawer, IconButton } from '@mui/material'
+import { Box, Drawer, IconButton } from '@mui/material'
 import Link from 'next/link'
 
 interface NavBarProps {
@@ -28,7 +28,7 @@ export const NavBar = ({ currentPage }: NavBarProps): JSX.Element => {
   return (
       <>
           {/* THIS SECTION IS THE DESKTOP SECTION OF THE NAVBAR */}
-          <AppBar component={'nav'} className={styles.navBar} data-testid={'nav-bar'}>
+          <Box component={'nav'} className={styles.navBar} data-testid={'nav-bar'}>
               <h1>
                   <Link data-testid={'landing-page-nav'} className={`${styles.navTitle} ${(currentPage === '/') ? styles.active : ''}`} href={'/'}>Spooky</Link>
               </h1>
@@ -56,7 +56,7 @@ export const NavBar = ({ currentPage }: NavBarProps): JSX.Element => {
               >
                   <MenuRounded />
               </IconButton>
-          </AppBar>
+          </Box>
           {/* THIS SECTION IS THE DRAWER OF THE NAVBAR ON MOBILE */}
           <Box component="nav">
               <Drawer


### PR DESCRIPTION
It's a huge pain in the ass to change the AppBar for server-side rendering, so I just said fuck it and switched to use a Box and that fixed the whole thing 🥳 

While I was in there, I switched the image to an image component and made the `h2` on the HeroSection go a little lower:
![image](https://github.com/brentdolan/spooky-list/assets/42629684/a21427f3-e1e5-49ab-8037-3225ce45bbcb)
